### PR TITLE
Add likes counter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
 /* eslint-disable */
-
-
 import './style.css';
 import pokeicon from './img/pokeicon.png';
 import sear from './img/sear.png';

--- a/src/modules/capstoneAPI.js
+++ b/src/modules/capstoneAPI.js
@@ -6,6 +6,7 @@ export default class Requestapicapstone {
     this.ulrlikes = `https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${this.idApp}/likes/`;
   }
 
+  
   getid = async () => {
     const val = await fetch(this.url, {
       method: 'POST',

--- a/src/modules/eleLiPok.js
+++ b/src/modules/eleLiPok.js
@@ -1,5 +1,4 @@
 import heart from '../img/heart.png';
-
 export default class lielement {
   static generateElement(name, img) {
     return `<li class="contentpoke">

--- a/src/modules/eleLiPok.js
+++ b/src/modules/eleLiPok.js
@@ -1,4 +1,5 @@
 import heart from '../img/heart.png';
+
 export default class lielement {
   static generateElement(name, img) {
     return `<li class="contentpoke">

--- a/src/modules/requestApi.js
+++ b/src/modules/requestApi.js
@@ -17,7 +17,6 @@ export default class Requestapi {
         data.sprites.front_default;
         elementsli += lielement.generateElement(e.name, data.sprites.front_default);
       }
-
       count += 1;
     }
     document.querySelector('.listPokemons').innerHTML = elementsli;
@@ -42,7 +41,6 @@ export default class Requestapi {
   getsPokemons = async () => {
     const response = await fetch('https://pokeapi.co/api/v2/pokemon?limit=100000&offset=0');
     const data = await response.json();
-
     return data;
   }
 


### PR DESCRIPTION
- Add counter for getting all pokemon from Api: data showed in the main view.
- Add see more pokemon counter: you can select all your pokemon you want to see: put a value and confirm
- Apply post like every time you press the heart to the pokemon
- Add different modules of counters from API pokemon and API capstone
- Add items for the home page
- Each counter should be implemented as a separate module.
- A counter function look for specific DOM elements.
- A counter function should cover all the edge cases you can think about. (you can do this by selecting the quantity of pokemon do you prefer)
- When the page loads, the web-app the shows the item likes and combines them with the data from the base API

Follow these steps to run the project ⚠️
step 1: execute in your terminal with the corresponding path"npm test"